### PR TITLE
Windows platform support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,3 +178,73 @@ jobs:
           path: |
             src-tauri/target/release/bundle/deb/*.deb
             src-tauri/target/release/bundle/appimage/*.AppImage
+
+  windows-check:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: TypeScript check
+        run: npx tsc --noEmit
+
+      - name: Rust check
+        working-directory: src-tauri
+        run: cargo check
+
+      - name: Rust clippy
+        working-directory: src-tauri
+        run: cargo clippy -- -D warnings
+
+      - name: Build frontend
+        run: npx vite build
+
+  windows-build:
+    needs: windows-check
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Tauri app (Windows)
+        run: npx tauri build
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ChatTerm-windows
+          path: |
+            src-tauri/target/release/bundle/msi/*.msi
+            src-tauri/target/release/bundle/nsis/*.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,3 +90,38 @@ jobs:
             src-tauri/target/release/bundle/deb/*.deb
             src-tauri/target/release/bundle/appimage/*.AppImage
           generate_release_notes: true
+
+  windows-release:
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Tauri app (Windows)
+        run: npx tauri build
+
+      - name: Upload Windows assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            src-tauri/target/release/bundle/msi/*.msi
+            src-tauri/target/release/bundle/nsis/*.exe
+          generate_release_notes: true

--- a/scripts/setup-hooks.ps1
+++ b/scripts/setup-hooks.ps1
@@ -1,0 +1,177 @@
+# ChatTerm agent hooks installer for Windows
+#
+# Usage:
+#   powershell -ExecutionPolicy Bypass -File scripts\setup-hooks.ps1
+#
+# Writes a hook at %APPDATA%\chatterm\hook.py and wires it into:
+#   - Claude Code (~/.claude/settings.json)
+#   - Kiro CLI    (~/.kiro/agents/chatterm.json)
+#   - Codex       (~/.codex/hooks.json)
+
+$ErrorActionPreference = "Stop"
+
+$HookDir = "$env:APPDATA\chatterm"
+$Hook = "$HookDir\hook.py"
+New-Item -ItemType Directory -Force -Path $HookDir | Out-Null
+
+# --- Install the hook script ---
+@'
+#!/usr/bin/env python3
+"""ChatTerm hook (Windows) - reads JSON on stdin, relays via Named Pipe."""
+import os, sys, json, datetime
+
+APPDATA = os.environ.get("APPDATA", os.path.expanduser("~"))
+PIPE = r"\\.\pipe\chatterm-hook"
+LOG  = os.path.join(APPDATA, "chatterm", "hook.log")
+SID  = os.environ.get("CHATTERM_SESSION_ID", "unknown")
+
+try:
+    raw = sys.stdin.read()
+    d = json.loads(raw) if raw.strip() else {}
+except Exception:
+    sys.exit(0)
+
+ev   = d.get("hook_event_name") or d.get("type") or ""
+tool = d.get("tool_name") or ""
+cwd  = d.get("cwd") or ""
+msg_raw = (d.get("last_assistant_message")
+           or d.get("message")
+           or d.get("output")
+           or "")
+if not isinstance(msg_raw, str):
+    msg_raw = str(msg_raw)
+msg = ""
+if msg_raw:
+    lines = [l.strip() for l in msg_raw.strip().splitlines() if l.strip()]
+    msg = lines[-1][:120] if lines else ""
+
+def emit(kind, body):
+    payload = json.dumps({"session_id": SID, "type": kind, "body": body, "cwd": cwd},
+                         ensure_ascii=False)
+    ts = datetime.datetime.now().strftime("%H:%M:%S")
+    try:
+        with open(LOG, "a") as f:
+            f.write(f"{ts} {payload}\n")
+    except OSError:
+        pass
+    try:
+        with open(PIPE, "w") as f:
+            f.write(payload + "\n")
+    except OSError:
+        return  # no reader / pipe missing
+
+mapping = {
+    "Stop":         ("reply", msg) if msg else ("done",  "Session complete"),
+    "stop":         ("reply", msg) if msg else ("done",  "Session complete"),
+    "PreToolUse":   ("tool",  f">> {tool}"),
+    "preToolUse":   ("tool",  f">> {tool}"),
+    "PostToolUse":  ("tool",  f"ok {tool}"),
+    "postToolUse":  ("tool",  f"ok {tool}"),
+    "Notification": ("ask",   msg or "Waiting for input"),
+    "response":     ("reply", msg),
+    "tool_call":    ("tool",  f">> {tool}"),
+    "tool_result":  ("tool",  f"ok {tool}"),
+}
+if ev in mapping:
+    kind, body = mapping[ev]
+    emit(kind, body)
+elif msg:
+    emit("event", msg)
+'@ | Set-Content -Path $Hook -Encoding UTF8
+Write-Host "Hook installed: $Hook"
+
+# --- Claude Code ---
+function Setup-Claude {
+    $dir = "$env:USERPROFILE\.claude"
+    $file = "$dir\settings.json"
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    python -c @"
+import json, os
+f=r'$file'
+h=r'$Hook'
+s = json.load(open(f)) if os.path.exists(f) else {}
+hook = {'type': 'command', 'command': f'python "{h}"'}
+changed = False
+for ev in ['Stop', 'PreToolUse', 'PostToolUse', 'Notification']:
+    rules = s.setdefault('hooks', {}).setdefault(ev, [])
+    new_rules = [r for r in rules if 'chatterm' not in str(r).lower()]
+    if new_rules != rules:
+        rules[:] = new_rules
+        changed = True
+    if not any(h in str(r) for r in rules):
+        rules.append({'matcher': '', 'hooks': [hook]})
+        changed = True
+if changed:
+    json.dump(s, open(f, 'w'), indent=2)
+    print('  Claude Code hooks configured')
+else:
+    print('  Claude Code hooks already configured')
+"@
+}
+
+# --- Kiro CLI ---
+function Setup-Kiro {
+    $dir = "$env:USERPROFILE\.kiro\agents"
+    $file = "$dir\chatterm.json"
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    if ((Test-Path $file) -and (Select-String -Path $file -Pattern "chatterm" -Quiet)) {
+        Write-Host "  Kiro CLI hooks already configured"
+        return
+    }
+    $hookCmd = "python `"$Hook`""
+    @"
+{
+  "name": "chatterm",
+  "description": "Default agent with ChatTerm notification hooks",
+  "tools": ["*"],
+  "allowedTools": ["*"],
+  "includeMcpJson": true,
+  "hooks": {
+    "stop": [{"command": "$hookCmd"}],
+    "preToolUse": [{"command": "$hookCmd"}],
+    "postToolUse": [{"command": "$hookCmd"}]
+  }
+}
+"@ | Set-Content -Path $file -Encoding UTF8
+    Write-Host "  Kiro CLI hooks configured (agent: chatterm)"
+}
+
+# --- Codex ---
+function Setup-Codex {
+    $dir = "$env:USERPROFILE\.codex"
+    $hooksFile = "$dir\hooks.json"
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    python -c @"
+import os, json
+path=r'$hooksFile'
+hook=r'$Hook'
+try:
+    data = json.load(open(path))
+except:
+    data = {}
+hooks = data.setdefault('hooks', {})
+desired = {
+    'Stop':       {'matcher': None,   'command': f'python "{hook}"'},
+    'PreToolUse': {'matcher': 'Bash', 'command': f'python "{hook}"'},
+    'PostToolUse':{'matcher': 'Bash', 'command': f'python "{hook}"'},
+}
+for event, spec in desired.items():
+    rules = hooks.setdefault(event, [])
+    rules[:] = [r for r in rules if 'chatterm' not in json.dumps(r).lower()]
+    rule = {'hooks': [{'type': 'command', 'command': spec['command']}]}
+    if spec['matcher']:
+        rule['matcher'] = spec['matcher']
+    rules.append(rule)
+json.dump(data, open(path, 'w'), indent=2)
+print('  Codex hooks configured')
+"@
+}
+
+Write-Host ""
+Write-Host "Configuring agents..."
+Setup-Claude
+Setup-Kiro
+Setup-Codex
+
+Write-Host ""
+Write-Host "Done! Restart agents to apply."

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -464,6 +464,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-opener",
  "vte",
+ "windows",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,4 +21,9 @@ portable-pty = "0.8"
 vte = "0.15"
 regex = "1"
 plist = "1"
+
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.61", features = ["Win32_System_Pipes", "Win32_System_IO", "Win32_Storage_FileSystem", "Win32_Foundation", "Win32_Security"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,8 @@ serde_json = "1"
 portable-pty = "0.8"
 vte = "0.15"
 regex = "1"
+
+[target.'cfg(target_os = "macos")'.dependencies]
 plist = "1"
 
 [target.'cfg(unix)'.dependencies]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -211,7 +211,7 @@ fn start_fifo_listener(app: AppHandle) {
             Ok(f) => f,
             Err(_) => { std::thread::sleep(std::time::Duration::from_millis(500)); continue; }
         };
-        for line in BufReader::new(file).lines().flatten() {
+        for line in BufReader::new(file).lines().map_while(Result::ok) {
             dispatch_pipe_line(&app, &line);
         }
     });
@@ -252,7 +252,7 @@ fn start_fifo_listener(app: AppHandle) {
             };
             let _ = unsafe { ConnectNamedPipe(handle, None) };
             let file = unsafe { std::fs::File::from_raw_handle(handle.0 as *mut _) };
-            for line in BufReader::new(file).lines().flatten() {
+            for line in BufReader::new(file).lines().map_while(Result::ok) {
                 dispatch_pipe_line(&app, &line);
             }
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -231,10 +231,13 @@ fn start_fifo_listener(app: AppHandle) {
 
     std::thread::spawn(move || {
         let pipe_name = b"\\\\.\\pipe\\chatterm-hook\0";
+        // PIPE_ACCESS_INBOUND (0x1) — windows crate exposes this as
+        // FILE_FLAGS_AND_ATTRIBUTES which doesn't impl BitOr with the pipe
+        // flags, so we define it here until the crate fixes the type.
+        const PIPE_ACCESS_INBOUND: windows::Win32::Storage::FileSystem::FILE_FLAGS_AND_ATTRIBUTES =
+            windows::Win32::Storage::FileSystem::FILE_FLAGS_AND_ATTRIBUTES(0x0000_0001);
         loop {
-            // PIPE_ACCESS_INBOUND = 0x00000001
-            let open_mode = windows::Win32::Storage::FileSystem::FILE_FLAGS_AND_ATTRIBUTES(0x1)
-                | FILE_FLAG_FIRST_PIPE_INSTANCE;
+            let open_mode = PIPE_ACCESS_INBOUND | FILE_FLAG_FIRST_PIPE_INSTANCE;
             let handle = unsafe {
                 CreateNamedPipeA(
                     PCSTR(pipe_name.as_ptr()),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,10 +17,7 @@ fn toggle_recording() -> bool {
     let now = !was;
     RECORDING.store(now, Ordering::Relaxed);
     if now {
-        let dir = format!(
-            "{}/.chatterm/recordings",
-            std::env::var("HOME").unwrap_or_default()
-        );
+        let dir = chatterm_dir().join("recordings");
         std::fs::remove_dir_all(&dir).ok();
         std::fs::create_dir_all(&dir).ok();
     }
@@ -149,91 +146,112 @@ pub fn run() {
         .expect("error while running tauri application");
 }
 
-/// FIFO IPC: hook scripts write JSON lines to this pipe, we emit pty-meta events
+/// Cross-platform chatterm data directory
+fn chatterm_dir() -> std::path::PathBuf {
+    #[cfg(windows)]
+    {
+        let base = std::env::var("APPDATA").unwrap_or_else(|_| {
+            std::env::var("USERPROFILE").unwrap_or_else(|_| "C:\\Users\\Default".into())
+        });
+        std::path::PathBuf::from(base).join("chatterm")
+    }
+    #[cfg(not(windows))]
+    {
+        let home = std::env::var("HOME").unwrap_or_default();
+        std::path::PathBuf::from(home).join(".chatterm")
+    }
+}
+
+fn dispatch_pipe_line(app: &AppHandle, line: &str) {
+    if line.trim().is_empty() {
+        return;
+    }
+    if let Ok(msg) = serde_json::from_str::<serde_json::Value>(line) {
+        let sid = msg.get("session_id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+        let body = msg.get("body").and_then(|v| v.as_str()).unwrap_or("").to_string();
+        let msg_type = msg.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        let msg_cwd = msg.get("cwd").and_then(|v| v.as_str()).filter(|s| !s.is_empty()).map(|s| s.to_string());
+        if !body.is_empty() {
+            let (state, preview) = match msg_type {
+                "reply" => (None, Some(body)),
+                "done" => (Some("idle".to_string()), None),
+                "ask" => (Some("idle".to_string()), None),
+                "tool" => (Some("thinking".to_string()), None),
+                _ => (None, None),
+            };
+            if state.is_some() || preview.is_some() || msg_cwd.is_some() {
+                app.emit("pty-meta", &PtyMeta {
+                    session_id: sid, title: None, agent: None,
+                    state, preview, notification: None, command: None, cwd: msg_cwd,
+                }).ok();
+            }
+        }
+    }
+}
+
+/// Unix: FIFO IPC
+#[cfg(unix)]
 fn start_fifo_listener(app: AppHandle) {
     use std::io::{BufRead, BufReader};
 
-    let pipe_path = format!(
-        "{}/.chatterm/hook.pipe",
-        std::env::var("HOME").unwrap_or_default()
-    );
-    let dir = format!("{}/.chatterm", std::env::var("HOME").unwrap_or_default());
+    let dir = chatterm_dir();
     std::fs::create_dir_all(&dir).ok();
+    let pipe_path = dir.join("hook.pipe");
 
-    // Remove stale pipe, create fresh FIFO
     std::fs::remove_file(&pipe_path).ok();
     unsafe {
         libc::mkfifo(
-            std::ffi::CString::new(pipe_path.as_str()).unwrap().as_ptr(),
+            std::ffi::CString::new(pipe_path.to_str().unwrap()).unwrap().as_ptr(),
             0o622,
         );
     }
 
+    std::thread::spawn(move || loop {
+        let file = match std::fs::File::open(&pipe_path) {
+            Ok(f) => f,
+            Err(_) => { std::thread::sleep(std::time::Duration::from_millis(500)); continue; }
+        };
+        for line in BufReader::new(file).lines().flatten() {
+            dispatch_pipe_line(&app, &line);
+        }
+    });
+}
+
+/// Windows: Named Pipe IPC
+#[cfg(windows)]
+fn start_fifo_listener(app: AppHandle) {
+    use std::io::{BufRead, BufReader};
+    use std::os::windows::io::FromRawHandle;
+    use windows::Win32::System::Pipes::*;
+    use windows::Win32::Storage::FileSystem::FILE_FLAG_FIRST_PIPE_INSTANCE;
+    use windows::core::PCSTR;
+
+    let dir = chatterm_dir();
+    std::fs::create_dir_all(&dir).ok();
+
     std::thread::spawn(move || {
+        let pipe_name = b"\\\\.\\pipe\\chatterm-hook\0";
         loop {
-            // open blocks until a writer connects; re-open after EOF to wait for next writer
-            let file = match std::fs::File::open(&pipe_path) {
-                Ok(f) => f,
-                Err(_) => {
-                    std::thread::sleep(std::time::Duration::from_millis(500));
-                    continue;
-                }
+            // PIPE_ACCESS_INBOUND = 0x00000001
+            let open_mode = windows::Win32::Storage::FileSystem::FILE_FLAGS_AND_ATTRIBUTES(0x1)
+                | FILE_FLAG_FIRST_PIPE_INSTANCE;
+            let handle = unsafe {
+                CreateNamedPipeA(
+                    PCSTR(pipe_name.as_ptr()),
+                    open_mode,
+                    PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+                    1, 4096, 4096, 0, None,
+                )
             };
-            let reader = BufReader::new(file);
-            for line in reader.lines() {
-                let line = match line {
-                    Ok(l) => l,
-                    Err(_) => break,
-                };
-                if line.trim().is_empty() {
-                    continue;
-                }
-                // Parse: {"session_id":"s0","type":"reply","body":"..."}
-                if let Ok(msg) = serde_json::from_str::<serde_json::Value>(&line) {
-                    let sid = msg
-                        .get("session_id")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let body = msg
-                        .get("body")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let msg_type = msg.get("type").and_then(|v| v.as_str()).unwrap_or("");
-                    let msg_cwd = msg
-                        .get("cwd")
-                        .and_then(|v| v.as_str())
-                        .filter(|s| !s.is_empty())
-                        .map(|s| s.to_string());
-                    if !body.is_empty() {
-                        let (state, preview) = match msg_type {
-                            "reply" => (None, Some(body)),
-                            "done" => (Some("idle".to_string()), None),
-                            "ask" => (Some("idle".to_string()), None),
-                            "tool" => (Some("thinking".to_string()), None),
-                            _ => (None, None),
-                        };
-                        if state.is_some() || preview.is_some() || msg_cwd.is_some() {
-                            app.emit(
-                                "pty-meta",
-                                &PtyMeta {
-                                    session_id: sid,
-                                    title: None,
-                                    agent: None,
-                                    state,
-                                    preview,
-                                    notification: None,
-                                    command: None,
-                                    cwd: msg_cwd,
-                                },
-                            )
-                            .ok();
-                        }
-                    }
-                }
+            let handle = match handle {
+                Ok(h) => h,
+                Err(_) => { std::thread::sleep(std::time::Duration::from_millis(500)); continue; }
+            };
+            let _ = unsafe { ConnectNamedPipe(handle, None) };
+            let file = unsafe { std::fs::File::from_raw_handle(handle.0 as *mut _) };
+            for line in BufReader::new(file).lines().flatten() {
+                dispatch_pipe_line(&app, &line);
             }
-            // Writer closed, loop back to re-open
         }
     });
 }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -640,6 +640,7 @@ fn descendants_of(root_pid: u32) -> std::collections::HashSet<u32> {
 }
 
 #[cfg(windows)]
+#[allow(dead_code)]
 fn descendants_of(_root_pid: u32) -> std::collections::HashSet<u32> {
     std::collections::HashSet::new() // TODO: implement via CreateToolhelp32Snapshot
 }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -402,12 +402,12 @@ impl PtyManager {
                                 preview: if preview_changed { preview } else { None },
                                 notification: notification.clone(),
                                 command: if agent_changed {
-                                    detect_agent_command(agent.as_deref())
+                                    detect_agent_command(agent.as_deref(), child_pid)
                                 } else {
                                     None
                                 },
                                 cwd: if agent_changed {
-                                    detect_agent_cwd(agent.as_deref())
+                                    detect_agent_cwd(agent.as_deref(), child_pid)
                                 } else {
                                     None
                                 },
@@ -570,23 +570,80 @@ fn extract_osc99(data: &str) -> Option<PtyNotification> {
     None
 }
 
-/// Detect the full command line and cwd of a running agent by scanning processes
-fn detect_agent_command(agent: Option<&str>) -> Option<String> {
+/// Return the set of PIDs that are transitive descendants of `root_pid`
+/// (not including `root_pid` itself). Used to scope agent detection to the
+/// session's own process subtree so unrelated instances of the same binary
+/// running elsewhere on the machine are not mis-attributed. Returns an empty
+/// set if `root_pid` is 0 or `ps` fails.
+fn descendants_of(root_pid: u32) -> std::collections::HashSet<u32> {
+    let mut descendants = std::collections::HashSet::new();
+    if root_pid == 0 {
+        return descendants;
+    }
+    let output = match std::process::Command::new("ps")
+        .args(["-eo", "pid,ppid"])
+        .output()
+        .ok()
+    {
+        Some(o) => o,
+        None => return descendants,
+    };
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut children: std::collections::HashMap<u32, Vec<u32>> = std::collections::HashMap::new();
+    for line in text.lines().skip(1) {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() < 2 {
+            continue;
+        }
+        let Ok(pid) = parts[0].parse::<u32>() else { continue };
+        let Ok(ppid) = parts[1].parse::<u32>() else { continue };
+        children.entry(ppid).or_default().push(pid);
+    }
+    let mut queue = vec![root_pid];
+    while let Some(pid) = queue.pop() {
+        if let Some(kids) = children.get(&pid) {
+            for &kid in kids {
+                if descendants.insert(kid) {
+                    queue.push(kid);
+                }
+            }
+        }
+    }
+    descendants
+}
+
+/// Detect the full command line and cwd of a running agent by scanning the
+/// descendants of `root_pid` (the session's own PTY child). Unrelated
+/// instances of the same binary elsewhere on the system are ignored.
+fn detect_agent_command(agent: Option<&str>, root_pid: u32) -> Option<String> {
     let bin = match agent? {
         "claude" => "claude",
         "kiro" => "kiro-cli",
         "codex" => "codex",
         _ => return None,
     };
+    let tree = descendants_of(root_pid);
+    if tree.is_empty() {
+        return None;
+    }
     let output = std::process::Command::new("ps")
-        .args(["-eo", "args"])
+        .args(["-eo", "pid,args"])
         .output()
         .ok()?;
     let text = String::from_utf8_lossy(&output.stdout);
-    for line in text.lines() {
+    for line in text.lines().skip(1) {
         let trimmed = line.trim();
-        let base = trimmed.split('/').next_back().unwrap_or(trimmed);
-        if base.starts_with(bin) && !trimmed.contains("hook") && !trimmed.contains("ps ") {
+        let (pid_s, args) = match trimmed.split_once(char::is_whitespace) {
+            Some((p, a)) => (p.trim(), a.trim()),
+            None => continue,
+        };
+        let Ok(pid) = pid_s.parse::<u32>() else { continue };
+        if !tree.contains(&pid) {
+            continue;
+        }
+        let base = args.split('/').next_back().unwrap_or(args);
+        if base.starts_with(bin) && !args.contains("hook") && !args.contains("ps ") {
+            let trimmed = args;
             // Clean up: "node /opt/homebrew/bin/codex --foo" → "codex --foo"
             //           "/Users/x/.local/bin/claude --foo" → "claude --foo"
             let parts: Vec<&str> = trimmed.split_whitespace().collect();
@@ -637,28 +694,35 @@ fn detect_agent_command(agent: Option<&str>) -> Option<String> {
     None
 }
 
-fn detect_agent_cwd(agent: Option<&str>) -> Option<String> {
+fn detect_agent_cwd(agent: Option<&str>, root_pid: u32) -> Option<String> {
     let bin = match agent? {
         "claude" => "claude",
         "kiro" => "kiro-cli",
         "codex" => "codex",
         _ => return None,
     };
+    let tree = descendants_of(root_pid);
+    if tree.is_empty() {
+        return None;
+    }
     let output = std::process::Command::new("ps")
         .args(["-eo", "pid,args"])
         .output()
         .ok()?;
     let text = String::from_utf8_lossy(&output.stdout);
-    for line in text.lines() {
+    for line in text.lines().skip(1) {
         let trimmed = line.trim();
         let parts: Vec<&str> = trimmed.splitn(2, char::is_whitespace).collect();
         if parts.len() < 2 {
             continue;
         }
+        let Ok(pid) = parts[0].parse::<u32>() else { continue };
+        if !tree.contains(&pid) {
+            continue;
+        }
         let base = parts[1].split('/').next_back().unwrap_or(parts[1]);
         if base.starts_with(bin) && !parts[1].contains("hook") {
-            let pid = parts[0].trim();
-            if let Some(cwd) = process_cwd(pid) {
+            if let Some(cwd) = process_cwd(&pid.to_string()) {
                 return Some(cwd);
             }
         }

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -83,17 +83,34 @@ impl PtyManager {
 
         let shell = detect_shell();
         let mut cmd = CommandBuilder::new(&shell);
+        #[cfg(not(windows))]
         cmd.arg("-l");
         if let Some(c) = req.command {
+            #[cfg(not(windows))]
             cmd.args(["-c", c]);
+            #[cfg(windows)]
+            {
+                // PowerShell uses -Command, cmd.exe uses /C
+                if shell.to_lowercase().contains("powershell") || shell.to_lowercase().contains("pwsh") {
+                    cmd.args(["-Command", c]);
+                } else {
+                    cmd.args(["/C", c]);
+                }
+            }
         }
 
         // Set HOME and common env
         let home = home_dir();
+        #[cfg(not(windows))]
         cmd.env("HOME", &home);
+        #[cfg(windows)]
+        cmd.env("USERPROFILE", &home);
         let work_dir = req.cwd.unwrap_or(&home);
         cmd.cwd(work_dir);
+        #[cfg(not(windows))]
         cmd.env("USER", whoami());
+        #[cfg(windows)]
+        cmd.env("USERNAME", whoami());
         if let Ok(path) = std::env::var("PATH") {
             cmd.env("PATH", expand_path(&home, &path));
         }
@@ -183,10 +200,8 @@ impl PtyManager {
 
                         // Record screen state to file (only when recording is enabled)
                         if crate::RECORDING.load(std::sync::atomic::Ordering::Relaxed) {
-                            let rec_dir = format!(
-                                "{}/.chatterm/recordings",
-                                std::env::var("HOME").unwrap_or_default()
-                            );
+                            let rec_dir_path = crate::chatterm_dir().join("recordings");
+                            let rec_dir = rec_dir_path.to_string_lossy().to_string();
                             std::fs::create_dir_all(&rec_dir).ok();
                             let ts = std::time::SystemTime::now()
                                 .duration_since(std::time::UNIX_EPOCH)
@@ -586,6 +601,7 @@ fn extract_osc99(data: &str) -> Option<PtyNotification> {
 /// session's own process subtree so unrelated instances of the same binary
 /// running elsewhere on the machine are not mis-attributed. Returns an empty
 /// set if `root_pid` is 0 or `ps` fails.
+#[cfg(not(windows))]
 fn descendants_of(root_pid: u32) -> std::collections::HashSet<u32> {
     let mut descendants = std::collections::HashSet::new();
     if root_pid == 0 {
@@ -623,9 +639,14 @@ fn descendants_of(root_pid: u32) -> std::collections::HashSet<u32> {
     descendants
 }
 
+#[cfg(windows)]
+fn descendants_of(_root_pid: u32) -> std::collections::HashSet<u32> {
+    std::collections::HashSet::new() // TODO: implement via CreateToolhelp32Snapshot
+}
 /// Detect the full command line and cwd of a running agent by scanning the
 /// descendants of `root_pid` (the session's own PTY child). Unrelated
 /// instances of the same binary elsewhere on the system are ignored.
+#[cfg(not(windows))]
 fn detect_agent_command(agent: Option<&str>, root_pid: u32) -> Option<String> {
     let bin = match agent? {
         "claude" => "claude",
@@ -705,6 +726,7 @@ fn detect_agent_command(agent: Option<&str>, root_pid: u32) -> Option<String> {
     None
 }
 
+#[cfg(not(windows))]
 fn detect_agent_cwd(agent: Option<&str>, root_pid: u32) -> Option<String> {
     let bin = match agent? {
         "claude" => "claude",
@@ -748,9 +770,8 @@ fn process_cwd(pid: &str) -> Option<String> {
         .and_then(|p| p.to_str().map(|s| s.to_string()))
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "macos")]
 fn process_cwd(pid: &str) -> Option<String> {
-    // lsof -a -p PID -d cwd: -a means AND all conditions.
     let lsof = std::process::Command::new("lsof")
         .args(["-a", "-p", pid, "-d", "cwd", "-Fn"])
         .output()
@@ -763,6 +784,17 @@ fn process_cwd(pid: &str) -> Option<String> {
     }
     None
 }
+
+#[cfg(windows)]
+fn process_cwd(_pid: &str) -> Option<String> {
+    None // TODO: implement via NtQueryInformationProcess
+}
+
+#[cfg(windows)]
+fn detect_agent_command(_agent: Option<&str>, _root_pid: u32) -> Option<String> { None }
+
+#[cfg(windows)]
+fn detect_agent_cwd(_agent: Option<&str>, _root_pid: u32) -> Option<String> { None }
 
 /// Extract terminal title from OSC 0/2 sequences: \033]0;TITLE\007
 fn extract_osc_title(data: &str) -> Option<String> {
@@ -794,7 +826,10 @@ fn detect_shell() -> String {
     if let Some(shell) = platform_shell() {
         return shell;
     }
-    "/bin/bash".to_string()
+    #[cfg(windows)]
+    { "powershell.exe".to_string() }
+    #[cfg(not(windows))]
+    { "/bin/bash".to_string() }
 }
 
 #[cfg(target_os = "macos")]
@@ -810,58 +845,84 @@ fn platform_shell() -> Option<String> {
         .then(|| shell.to_string())
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", windows)))]
 fn platform_shell() -> Option<String> {
     None
 }
 
+#[cfg(windows)]
+fn platform_shell() -> Option<String> {
+    // Prefer pwsh (PowerShell 7+) if available, else fall back to powershell.exe
+    if let Ok(o) = std::process::Command::new("where").arg("pwsh.exe").output() {
+        let s = String::from_utf8_lossy(&o.stdout);
+        let p = s.trim();
+        if !p.is_empty() { return Some(p.to_string()); }
+    }
+    None
+}
+
 fn whoami() -> String {
-    std::env::var("USER").unwrap_or_else(|_| {
-        String::from_utf8_lossy(
-            &std::process::Command::new("whoami")
-                .output()
-                .map(|o| o.stdout)
-                .unwrap_or_default(),
-        )
-        .trim()
-        .to_string()
-    })
+    #[cfg(windows)]
+    { std::env::var("USERNAME").unwrap_or_else(|_| "user".into()) }
+    #[cfg(not(windows))]
+    {
+        std::env::var("USER").unwrap_or_else(|_| {
+            String::from_utf8_lossy(
+                &std::process::Command::new("whoami")
+                    .output()
+                    .map(|o| o.stdout)
+                    .unwrap_or_default(),
+            )
+            .trim()
+            .to_string()
+        })
+    }
 }
 
 fn home_dir() -> String {
-    std::env::var("HOME").unwrap_or_else(|_| {
-        #[cfg(target_os = "macos")]
-        {
-            format!("/Users/{}", whoami())
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
-            format!("/home/{}", whoami())
-        }
-    })
+    #[cfg(windows)]
+    {
+        std::env::var("USERPROFILE").unwrap_or_else(|_| {
+            format!("C:\\Users\\{}", whoami())
+        })
+    }
+    #[cfg(not(windows))]
+    {
+        std::env::var("HOME").unwrap_or_else(|_| {
+            #[cfg(target_os = "macos")]
+            { format!("/Users/{}", whoami()) }
+            #[cfg(not(target_os = "macos"))]
+            { format!("/home/{}", whoami()) }
+        })
+    }
 }
 
 fn expand_path(_home: &str, path: &str) -> String {
-    let mut prefixes = Vec::new();
-    #[cfg(target_os = "macos")]
+    #[cfg(windows)]
+    { path.to_string() }
+    #[cfg(not(windows))]
     {
-        prefixes.push("/opt/homebrew/bin".to_string());
-        prefixes.push("/usr/local/bin".to_string());
-    }
-    #[cfg(target_os = "linux")]
-    {
-        prefixes.push(format!("{_home}/.local/bin"));
-        prefixes.push("/usr/local/bin".to_string());
-    }
-
-    let mut merged = Vec::new();
-    for prefix in prefixes {
-        if !path.split(':').any(|entry| entry == prefix) {
-            merged.push(prefix);
+        let mut prefixes = Vec::new();
+        #[cfg(target_os = "macos")]
+        {
+            prefixes.push("/opt/homebrew/bin".to_string());
+            prefixes.push("/usr/local/bin".to_string());
         }
+        #[cfg(target_os = "linux")]
+        {
+            prefixes.push(format!("{_home}/.local/bin"));
+            prefixes.push("/usr/local/bin".to_string());
+        }
+
+        let mut merged = Vec::new();
+        for prefix in prefixes {
+            if !path.split(':').any(|entry| entry == prefix) {
+                merged.push(prefix);
+            }
+        }
+        merged.push(path.to_string());
+        merged.join(":")
     }
-    merged.push(path.to_string());
-    merged.join(":")
 }
 
 // Wrapper to implement portable_pty::Child for std::process::Child

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -99,6 +99,17 @@ impl PtyManager {
         }
         cmd.env("TERM", "xterm-256color");
         cmd.env("CHATTERM_SESSION_ID", req.id);
+        // Pass locale through so `less`, git, etc. render multibyte characters
+        // (CJK names, filenames) instead of escaping bytes as <hex>. GUI apps
+        // launched by launchd inherit a bare environment without LANG.
+        for var in ["LANG", "LC_ALL", "LC_CTYPE"] {
+            if let Ok(v) = std::env::var(var) {
+                cmd.env(var, v);
+            }
+        }
+        if std::env::var("LANG").is_err() && std::env::var("LC_ALL").is_err() {
+            cmd.env("LANG", "en_US.UTF-8");
+        }
 
         let child = pair
             .slave

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -13,8 +13,18 @@ pub struct SessionMeta {
 }
 
 fn meta_path() -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_default();
-    PathBuf::from(format!("{}/.chatterm/sessions.json", home))
+    #[cfg(windows)]
+    {
+        let base = std::env::var("APPDATA").unwrap_or_else(|_| {
+            std::env::var("USERPROFILE").unwrap_or_else(|_| "C:\\Users\\Default".into())
+        });
+        PathBuf::from(base).join("chatterm").join("sessions.json")
+    }
+    #[cfg(not(windows))]
+    {
+        let home = std::env::var("HOME").unwrap_or_default();
+        PathBuf::from(home).join(".chatterm").join("sessions.json")
+    }
 }
 
 pub fn load() -> Vec<SessionMeta> {

--- a/src-tauri/src/theme.rs
+++ b/src-tauri/src/theme.rs
@@ -1,5 +1,7 @@
+#[cfg(target_os = "macos")]
 use plist::Value;
 use serde::Serialize;
+#[cfg(target_os = "macos")]
 use std::path::Path;
 
 #[derive(Debug, Clone, Serialize)]
@@ -37,6 +39,7 @@ pub struct ThemeColors {
 }
 
 /// Parse a .terminal plist file and extract theme colors
+#[cfg(target_os = "macos")]
 pub fn parse_terminal_file(path: &str) -> Result<ThemeColors, String> {
     let val = Value::from_file(path).map_err(|e| format!("Failed to read plist: {e}"))?;
     let dict = val
@@ -86,7 +89,13 @@ pub fn parse_terminal_file(path: &str) -> Result<ThemeColors, String> {
     })
 }
 
+#[cfg(not(target_os = "macos"))]
+pub fn parse_terminal_file(_path: &str) -> Result<ThemeColors, String> {
+    Err("Terminal theme import is only available on macOS".to_string())
+}
+
 /// Parse NSKeyedArchiver color data to #rrggbb hex
+#[cfg(target_os = "macos")]
 fn parse_nscolor(data: &[u8]) -> Option<String> {
     let val = plist::Value::from_reader(std::io::Cursor::new(data)).ok()?;
     let dict = val.as_dictionary()?;
@@ -117,6 +126,7 @@ fn parse_nscolor(data: &[u8]) -> Option<String> {
     None
 }
 
+#[cfg(target_os = "macos")]
 fn parse_rgb_components(data: &[u8]) -> Option<String> {
     let s = String::from_utf8_lossy(data)
         .trim_end_matches('\0')

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,7 +35,8 @@
       "icons/icon.ico"
     ],
     "resources": {
-      "../scripts/setup-hooks.sh": "setup-hooks.sh"
+      "../scripts/setup-hooks.sh": "setup-hooks.sh",
+      "../scripts/setup-hooks.ps1": "setup-hooks.ps1"
     }
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -144,9 +144,15 @@ export default function App() {
           }
         }
 
-        // Capture agent command from process detection
+        // Capture agent command — but only when it belongs to the session's
+        // current agent. Without this guard, a cross-agent match in the
+        // backend (e.g. detecting codex while session is still labelled kiro)
+        // could silently overwrite command with an unrelated process's args.
         if (command) {
-          (updates as any)._command = command;
+          const currentAgent = (s as any)._agent;
+          if (!currentAgent || !agent || agent === currentAgent) {
+            (updates as any)._command = command;
+          }
         }
 
         // Update cwd from hook

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -269,9 +269,11 @@ export default function App() {
         if (k === "n") { e.preventDefault(); handleNew(); }
       }
       if (e.key === "Escape") {
-        e.preventDefault(); e.stopPropagation();
-        if (themeOpen) { setThemeOpen(false); return; }
-        if (cmdkOpen) { setCmdkOpen(false); return; }
+        // Only swallow ESC when an overlay is actually open; otherwise let it
+        // bubble to xterm so vim / Kiro CLI / anything else in the terminal
+        // sees it.
+        if (themeOpen) { e.preventDefault(); e.stopPropagation(); setThemeOpen(false); return; }
+        if (cmdkOpen) { e.preventDefault(); e.stopPropagation(); setCmdkOpen(false); return; }
       }
     };
     window.addEventListener("keydown", handler, true); // capture phase

--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -279,7 +279,7 @@ export default function Sidebar({ sessions, activeId, onSelect, onNew, onSearch,
         }}>Y</div>
         <div style={{ flex: 1, minWidth: 0, display: "flex", alignItems: "baseline", gap: 6 }}>
           <div style={{ fontSize: 11, color: "var(--text-dim)" }}>Built for AI coding sessions.</div>
-          <div className="mono" style={{ fontSize: 10, color: "var(--text-mute)" }}>v0.1.0</div>
+          <div className="mono" style={{ fontSize: 10, color: "var(--text-mute)" }}>v{__APP_VERSION__}</div>
         </div>
         <Ic.settings style={{ color: "var(--text-dim)", cursor: "pointer" }} onClick={onSettings} />
       </div>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,9 @@ const host = process.env.TAURI_DEV_HOST;
 // https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
+  },
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   //


### PR DESCRIPTION
## Summary

Adds full Windows build and runtime support for ChatTerm. Closes #6.

## Changes

### Core (`src-tauri/src/`)
- **`lib.rs`** — Extract `chatterm_dir()` for cross-platform data dir (`APPDATA` on Windows, `~/.chatterm` on Unix). Split `start_fifo_listener` into Unix FIFO and Windows Named Pipe (`\\.\pipe\chatterm-hook`) implementations.
- **`pty.rs`** — Add Windows branches for `detect_shell` (PowerShell), `home_dir` (`USERPROFILE`), `whoami` (`USERNAME`), `expand_path` (no-op on Windows). Skip `-l` flag, use `-Command` for PowerShell. Stub `process_cwd`/`descendants_of`/`detect_agent_cwd`/`detect_agent_command` as None/empty on Windows (tracked in #7).
- **`session.rs`** — Use `APPDATA` for session metadata path on Windows.
- **`theme.rs`** — Gate plist-dependent code behind `#[cfg(target_os = "macos")]`.

### Dependencies (`Cargo.toml`)
- `libc` → `cfg(unix)` only
- `plist` → `cfg(target_os = "macos")` only
- Added `windows` crate for Named Pipe API (`cfg(windows)`)

### Scripts & CI
- Added `scripts/setup-hooks.ps1` — Windows hook installer (Named Pipe + Claude/Kiro/Codex config)
- Added `windows-check` + `windows-build` jobs to `ci.yml`
- Added `windows-release` job to `release.yml` (MSI + NSIS)

## Verified on Windows
- [x] `cargo check` — zero errors, zero warnings
- [x] `cargo build` — release build succeeds
- [x] `tauri build` — produces MSI + NSIS installer
- [x] App launches, PowerShell session works
- [x] Multi-session, command execution, window resize all functional
- [x] macOS build unaffected (no regression)

## Known limitations (tracked in #7)
- Agent process detection (`descendants_of`, `process_cwd`) stubbed on Windows — sidebar won't show agent command/cwd