### PR TITLE
feat: SSH remote CWD tracking via OSC 7 + Windows process_cwd

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,4 +28,11 @@ plist = "1"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.61", features = ["Win32_System_Pipes", "Win32_System_IO", "Win32_Storage_FileSystem", "Win32_Foundation", "Win32_Security"] }
+windows = { version = "0.61", features = [
+    # Named Pipe IPC (hook listener)
+    "Win32_System_Pipes", "Win32_System_IO", "Win32_Storage_FileSystem",
+    "Win32_Foundation", "Win32_Security",
+    # process_cwd: NtQueryInformationProcess + ReadProcessMemory
+    "Win32_System_Threading", "Win32_System_Diagnostics_Debug",
+    "Win32_System_LibraryLoader",
+] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -206,7 +206,7 @@ fn start_fifo_listener(app: AppHandle) {
     unsafe {
         libc::mkfifo(
             std::ffi::CString::new(pipe_path.to_str().unwrap()).unwrap().as_ptr(),
-            0o622,
+            0o600,
         );
     }
 

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -154,6 +154,10 @@ impl PtyManager {
             let mut last_shell_cwd: Option<String> = None;
             let mut last_cwd_probe = std::time::Instant::now()
                 - std::time::Duration::from_secs(10);
+            // When OSC 7 reports a remote hostname, disable the /proc-based
+            // fallback probe — it would read the local `ssh` process's cwd
+            // and overwrite the correct remote path.
+            let mut cwd_via_remote_osc7 = false;
             let mut vscreen = VScreen::new();
 
             // Best-effort initial push of cwd. A single emit can race with the
@@ -252,6 +256,37 @@ impl PtyManager {
                                 state = cfg.detect_state_from_title(&t).map(|s| s.to_string());
                             }
                             title = Some(t);
+                        }
+
+                        // OSC 7 CWD tracking (works across SSH — remote shell
+                        // sends file://hostname/path which tunnels back through PTY)
+                        if let Some((host, path)) = extract_osc7(&data) {
+                            let local = host.is_empty()
+                                || host == "localhost"
+                                || is_local_hostname(&host);
+                            let new_cwd = if local {
+                                path
+                            } else {
+                                // Wrap bare IPv6 addresses in brackets so the
+                                // frontend regex can distinguish host from path
+                                let display_host = if host.contains(':') {
+                                    format!("[{}]", host)
+                                } else {
+                                    host
+                                };
+                                format!("{}:{}", display_host, path)
+                            };
+                            cwd_via_remote_osc7 = !local;
+                            if Some(&new_cwd) != last_shell_cwd.as_ref() {
+                                last_shell_cwd = Some(new_cwd.clone());
+                                last_cwd_probe = std::time::Instant::now();
+                                on_meta(PtyMeta {
+                                    session_id: session_id.clone(),
+                                    title: None, agent: None, state: None,
+                                    preview: None, notification: None, command: None,
+                                    cwd: Some(new_cwd),
+                                });
+                            }
                         }
 
                         // Detect agent from content (always try, allows switching agents)
@@ -443,23 +478,39 @@ impl PtyManager {
                         // Live shell cwd tracking — only for non-agent sessions
                         // (agents have their own cwd discovery via detect_agent_cwd).
                         // Throttled to once per 500ms worth of output bursts.
+                        // When cwd_via_remote_osc7 is set, we still probe /proc
+                        // but only accept the result if it differs from the ssh
+                        // process's own cwd — this detects when the user has
+                        // exited SSH and the foreground process changed.
                         if last_agent_cfg.is_none()
                             && child_pid > 0
                             && last_cwd_probe.elapsed() >= std::time::Duration::from_millis(500)
                         {
                             last_cwd_probe = std::time::Instant::now();
                             if let Some(new_cwd) = process_cwd(&child_pid.to_string()) {
-                                if Some(&new_cwd) != last_shell_cwd.as_ref() {
+                                if cwd_via_remote_osc7 {
+                                    // During SSH, /proc reads the local shell's
+                                    // cwd which stays frozen. We still probe so
+                                    // that when SSH exits and the shell resumes,
+                                    // we detect the cwd is now a local path and
+                                    // re-enable local tracking. The first /proc
+                                    // read after SSH exit resets the flag; the
+                                    // next iteration emits the update.
+                                    cwd_via_remote_osc7 = false;
                                     last_shell_cwd = Some(new_cwd.clone());
                                     on_meta(PtyMeta {
                                         session_id: session_id.clone(),
-                                        title: None,
-                                        agent: None,
-                                        state: None,
-                                        preview: None,
-                                        notification: None,
-                                        command: None,
-                                        cwd: Some(new_cwd),
+                                        title: None, agent: None, state: None,
+                                        preview: None, notification: None,
+                                        command: None, cwd: Some(new_cwd),
+                                    });
+                                } else if Some(&new_cwd) != last_shell_cwd.as_ref() {
+                                    last_shell_cwd = Some(new_cwd.clone());
+                                    on_meta(PtyMeta {
+                                        session_id: session_id.clone(),
+                                        title: None, agent: None, state: None,
+                                        preview: None, notification: None,
+                                        command: None, cwd: Some(new_cwd),
                                     });
                                 }
                             }
@@ -594,6 +645,54 @@ fn extract_osc99(data: &str) -> Option<PtyNotification> {
         }
     }
     None
+}
+
+/// Parse OSC 7 (shell CWD reporting): \033]7;file://HOSTNAME/PATH\007 or \033]7;...;\033\\
+/// Returns (hostname, path). Used to track CWD across SSH sessions where
+/// /proc or lsof cannot reach the remote shell.
+///
+/// NOTE: Only the `file://` scheme is handled. Some terminals emit bare paths
+/// (`\033]7;/home/user\007`) without the scheme — those are intentionally
+/// ignored and fall through to the /proc-based fallback.
+fn extract_osc7(data: &str) -> Option<(String, String)> {
+    let marker = "\x1b]7;file://";
+    // Use rfind so that if multiple OSC 7 sequences arrive in one read
+    // (e.g. rapid `cd` commands), we pick the last (most recent) one.
+    let start = data.rfind(marker)? + marker.len();
+    let rest = &data[start..];
+    let end = rest.find('\x07').or_else(|| rest.find("\x1b\\"))?;
+    let payload = &rest[..end];
+    let slash = payload.find('/')?;
+    let host = percent_decode(&payload[..slash]);
+    let path = percent_decode(&payload[slash..]);
+    // Basic path validation: reject traversal attempts (e.g. /../../../etc)
+    if path.split('/').any(|seg| seg == "..") {
+        return None;
+    }
+    Some((host, path))
+}
+
+/// Decode percent-encoded bytes in a URI path (RFC 3986).
+/// Handles `%20` → space, `%E4%BD%A0` → 你, etc.
+fn percent_decode(s: &str) -> String {
+    let mut out = Vec::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let Ok(b) = u8::from_str_radix(
+                std::str::from_utf8(&bytes[i + 1..i + 3]).unwrap_or(""),
+                16,
+            ) {
+                out.push(b);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 /// Return the set of PIDs that are transitive descendants of `root_pid`
@@ -787,8 +886,162 @@ fn process_cwd(pid: &str) -> Option<String> {
 }
 
 #[cfg(windows)]
-fn process_cwd(_pid: &str) -> Option<String> {
-    None // TODO: implement via NtQueryInformationProcess
+fn process_cwd(pid: &str) -> Option<String> {
+    // Only x64 PEB offsets are defined; reject 32-bit at compile time.
+    #[cfg(not(target_pointer_width = "64"))]
+    compile_error!("Windows process_cwd() only supports 64-bit targets");
+
+    use windows::Win32::System::Threading::{
+        OpenProcess, PROCESS_QUERY_INFORMATION, PROCESS_VM_READ,
+    };
+
+    let pid_u32: u32 = pid.parse().ok()?;
+
+    // RAII wrapper so the handle is closed even if read_process_cwd panics.
+    struct OwnedHandle(windows::Win32::Foundation::HANDLE);
+    impl Drop for OwnedHandle {
+        fn drop(&mut self) {
+            unsafe { let _ = windows::Win32::Foundation::CloseHandle(self.0); }
+        }
+    }
+
+    let handle = unsafe {
+        OpenProcess(
+            PROCESS_QUERY_INFORMATION | PROCESS_VM_READ,
+            false,
+            pid_u32,
+        ).ok()?
+    };
+    let owned = OwnedHandle(handle);
+    unsafe { read_process_cwd(owned.0) }
+}
+
+/// Cached NtQueryInformationProcess function pointer (loaded once from ntdll).
+#[cfg(windows)]
+type NtQueryFn = unsafe extern "system" fn(
+    handle: isize,   // HANDLE
+    class: u32,      // PROCESSINFOCLASS
+    info: *mut u8,   // output buffer
+    len: u32,        // buffer size
+    ret_len: *mut u32,
+) -> i32; // NTSTATUS
+
+#[cfg(windows)]
+fn cached_nt_query() -> Option<NtQueryFn> {
+    use std::sync::OnceLock;
+    static FUNC: OnceLock<Option<NtQueryFn>> = OnceLock::new();
+    *FUNC.get_or_init(|| unsafe {
+        // ntdll.dll is always loaded in every Windows process — use
+        // GetModuleHandleA (no refcount bump) instead of LoadLibraryA.
+        let ntdll = windows::Win32::System::LibraryLoader::GetModuleHandleA(
+            windows::core::PCSTR(b"ntdll.dll\0".as_ptr()),
+        ).ok()?;
+        let func = windows::Win32::System::LibraryLoader::GetProcAddress(
+            ntdll,
+            windows::core::PCSTR(b"NtQueryInformationProcess\0".as_ptr()),
+        )?;
+        Some(std::mem::transmute(func))
+    })
+}
+
+/// Read CWD from a remote process via NtQueryInformationProcess → PEB → ProcessParameters.
+///
+/// x64 layout only — guarded by compile_error! in `process_cwd()`.
+#[cfg(windows)]
+unsafe fn read_process_cwd(handle: windows::Win32::Foundation::HANDLE) -> Option<String> {
+    let nt_query = cached_nt_query()?;
+
+    // PROCESS_BASIC_INFORMATION (x64):
+    //   NTSTATUS ExitStatus       (i32 + 4 bytes padding)
+    //   PPEB     PebBaseAddress   (usize)
+    //   ULONG_PTR AffinityMask    (usize)
+    //   KPRIORITY BasePriority    (i32 + 4 bytes padding)
+    //   ULONG_PTR UniqueProcessId (usize)
+    //   ULONG_PTR InheritedFromUniqueProcessId (usize)
+    #[repr(C)]
+    struct ProcessBasicInformation {
+        exit_status: i32,
+        _pad0: u32,
+        peb_base_address: usize,
+        affinity_mask: usize,
+        base_priority: i32,
+        _pad1: u32,
+        unique_process_id: usize,
+        inherited_from_unique_process_id: usize,
+    }
+    const _: () = assert!(std::mem::size_of::<ProcessBasicInformation>() == 48);
+
+    let mut pbi = std::mem::zeroed::<ProcessBasicInformation>();
+    // .0 accesses the raw isize inside windows::Win32::Foundation::HANDLE
+    let status = nt_query(
+        handle.0 as isize,                                  // process handle
+        0,                                                   // ProcessBasicInformation
+        &mut pbi as *mut _ as *mut u8,                       // output buffer
+        std::mem::size_of::<ProcessBasicInformation>() as u32, // buffer size
+        std::ptr::null_mut(),                                // optional return length
+    );
+    if status < 0 || pbi.peb_base_address == 0 {
+        return None;
+    }
+
+    // PEB.ProcessParameters pointer: offset 0x20 on x64
+    let mut params_ptr: usize = 0;
+    read_mem(handle, pbi.peb_base_address + 0x20, &mut params_ptr)?;
+    if params_ptr == 0 {
+        return None;
+    }
+
+    // RTL_USER_PROCESS_PARAMETERS.CurrentDirectory is a CURDIR at offset 0x38 (x64).
+    // CURDIR starts with a UNICODE_STRING: { Length: u16, MaxLength: u16, pad: u32, Buffer: usize }
+    let mut len: u16 = 0;
+    read_mem(handle, params_ptr + 0x38, &mut len)?;
+    // Windows long-path max is 32767 chars = 65534 bytes
+    if len == 0 || len as usize > 32767 * 2 {
+        return None;
+    }
+
+    // Buffer pointer at +8 bytes from UNICODE_STRING start (after Length + MaxLength + padding)
+    let mut buf_ptr: usize = 0;
+    read_mem(handle, params_ptr + 0x38 + 8, &mut buf_ptr)?;
+    if buf_ptr == 0 {
+        return None;
+    }
+
+    let char_count = len as usize / 2;
+    let mut buf = vec![0u16; char_count];
+    let mut bytes_read = 0usize;
+    let ok = windows::Win32::System::Diagnostics::Debug::ReadProcessMemory(
+        handle,
+        buf_ptr as *const _,
+        buf.as_mut_ptr() as *mut _,
+        char_count * 2,
+        Some(&mut bytes_read),
+    );
+    if ok.is_err() || bytes_read < char_count * 2 {
+        return None;
+    }
+
+    let s = String::from_utf16_lossy(&buf);
+    // Strip trailing backslash (e.g. "C:\Users\foo\" → "C:\Users\foo")
+    Some(s.trim_end_matches('\\').to_string())
+}
+
+#[cfg(windows)]
+unsafe fn read_mem<T: Copy>(
+    handle: windows::Win32::Foundation::HANDLE,
+    addr: usize,
+    out: &mut T,
+) -> Option<()> {
+    let mut read = 0usize;
+    windows::Win32::System::Diagnostics::Debug::ReadProcessMemory(
+        handle,
+        addr as *const _,
+        out as *mut T as *mut _,
+        std::mem::size_of::<T>(),
+        Some(&mut read),
+    )
+    .ok()?;
+    Some(())
 }
 
 #[cfg(windows)]
@@ -860,6 +1113,33 @@ fn platform_shell() -> Option<String> {
         if !p.is_empty() { return Some(p.to_string()); }
     }
     None
+}
+
+/// Check if a hostname matches the local machine, avoiding false SSH detection
+/// when the local shell's OSC 7 uses the machine's actual hostname.
+fn is_local_hostname(host: &str) -> bool {
+    use std::sync::OnceLock;
+    static LOCAL: OnceLock<String> = OnceLock::new();
+    let local = LOCAL.get_or_init(|| {
+        #[cfg(unix)]
+        {
+            let mut buf = [0u8; 256];
+            unsafe {
+                if libc::gethostname(buf.as_mut_ptr() as *mut _, buf.len()) == 0 {
+                    let len = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+                    return String::from_utf8_lossy(&buf[..len]).into_owned();
+                }
+            }
+        }
+        #[cfg(windows)]
+        {
+            if let Ok(h) = std::env::var("COMPUTERNAME") {
+                return h;
+            }
+        }
+        String::new()
+    });
+    !local.is_empty() && host == local.as_str()
 }
 
 fn whoami() -> String {

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -98,6 +98,27 @@ impl PtyManager {
                 }
             }
         }
+        #[cfg(windows)]
+        {
+            // PowerShell 5.x does not update the terminal title on cd, and
+            // does not call SetCurrentDirectory (so process_cwd() is stale).
+            // Inject an OSC 7 prompt hook so CWD tracking works out of the box.
+            if req.command.is_none()
+                && (shell.to_lowercase().contains("powershell")
+                    || shell.to_lowercase().contains("pwsh"))
+            {
+                cmd.args(["-NoExit", "-Command",
+                    // Prepend an OSC 7 emitter to the existing prompt function.
+                    // Emit OSC 7 before every prompt for CWD tracking.
+                    // Uses $([char]27) for PS 5.x compat. The prompt function
+                    // emits OSC 7 then returns the default "PS path> " prompt.
+                    // If $PROFILE redefines prompt after this, OSC 7 is lost —
+                    // but the OSC 0 title fallback (extract_windows_path_from_title)
+                    // still provides CWD tracking for pwsh 7+ which sets title.
+                    r#"function prompt { $p = $PWD.Path -replace '\\','/'; [Console]::Write($([char]27) + "]7;file://" + $env:COMPUTERNAME + "/" + $p + $([char]27) + "\"); return "PS $($PWD.Path)> " }"#,
+                ]);
+            }
+        }
 
         // Set HOME and common env
         let home = home_dir();
@@ -158,6 +179,11 @@ impl PtyManager {
             // fallback probe — it would read the local `ssh` process's cwd
             // and overwrite the correct remote path.
             let mut cwd_via_remote_osc7 = false;
+            // When ANY OSC 7 has been received (local or remote), the shell
+            // is emitting CWD via OSC 7. Use a timestamp so the suppression
+            // self-heals: if the shell stops emitting OSC 7 (e.g. user runs
+            // cmd.exe inside PowerShell), process_cwd() resumes after 10s.
+            let mut last_osc7_time: Option<std::time::Instant> = None;
             let mut vscreen = VScreen::new();
 
             // Best-effort initial push of cwd. A single emit can race with the
@@ -277,6 +303,7 @@ impl PtyManager {
                                 format!("{}:{}", display_host, path)
                             };
                             cwd_via_remote_osc7 = !local;
+                            last_osc7_time = Some(std::time::Instant::now());
                             if Some(&new_cwd) != last_shell_cwd.as_ref() {
                                 last_shell_cwd = Some(new_cwd.clone());
                                 last_cwd_probe = std::time::Instant::now();
@@ -286,6 +313,27 @@ impl PtyManager {
                                     preview: None, notification: None, command: None,
                                     cwd: Some(new_cwd),
                                 });
+                            }
+                        }
+
+                        // Fallback CWD from OSC 0 title — PowerShell sets the
+                        // terminal title to the current directory (e.g. "C:\Users\foo"
+                        // or "PS C:\Users\foo>") but does NOT call SetCurrentDirectory,
+                        // so process_cwd() returns a stale path. Extract a Windows
+                        // path from the title as a fallback when no OSC 7 is active.
+                        if !cwd_via_remote_osc7 && last_agent_cfg.is_none() {
+                            if let Some(ref t) = title {
+                                if let Some(cwd) = extract_windows_path_from_title(t) {
+                                    if Some(&cwd) != last_shell_cwd.as_ref() {
+                                        last_shell_cwd = Some(cwd.clone());
+                                        on_meta(PtyMeta {
+                                            session_id: session_id.clone(),
+                                            title: None, agent: None, state: None,
+                                            preview: None, notification: None,
+                                            command: None, cwd: Some(cwd),
+                                        });
+                                    }
+                                }
                             }
                         }
 
@@ -475,36 +523,22 @@ impl PtyManager {
                             });
                         }
 
-                        // Live shell cwd tracking — only for non-agent sessions
-                        // (agents have their own cwd discovery via detect_agent_cwd).
+                        // Live shell cwd tracking — only for non-agent sessions.
                         // Throttled to once per 500ms worth of output bursts.
-                        // When cwd_via_remote_osc7 is set, we still probe /proc
-                        // but only accept the result if it differs from the ssh
-                        // process's own cwd — this detects when the user has
-                        // exited SSH and the foreground process changed.
+                        // Skip entirely while OSC 7 is the CWD source — either
+                        // from a remote SSH session or a local shell with OSC 7
+                        // prompt (e.g. our injected PowerShell prompt). On Windows
+                        // process_cwd() reads a stale PEB that would overwrite
+                        // the correct OSC 7 path.
                         if last_agent_cfg.is_none()
                             && child_pid > 0
+                            && !cwd_via_remote_osc7
+                            && last_osc7_time.is_none_or(|t| t.elapsed() >= std::time::Duration::from_secs(10))
                             && last_cwd_probe.elapsed() >= std::time::Duration::from_millis(500)
                         {
                             last_cwd_probe = std::time::Instant::now();
                             if let Some(new_cwd) = process_cwd(&child_pid.to_string()) {
-                                if cwd_via_remote_osc7 {
-                                    // During SSH, /proc reads the local shell's
-                                    // cwd which stays frozen. We still probe so
-                                    // that when SSH exits and the shell resumes,
-                                    // we detect the cwd is now a local path and
-                                    // re-enable local tracking. The first /proc
-                                    // read after SSH exit resets the flag; the
-                                    // next iteration emits the update.
-                                    cwd_via_remote_osc7 = false;
-                                    last_shell_cwd = Some(new_cwd.clone());
-                                    on_meta(PtyMeta {
-                                        session_id: session_id.clone(),
-                                        title: None, agent: None, state: None,
-                                        preview: None, notification: None,
-                                        command: None, cwd: Some(new_cwd),
-                                    });
-                                } else if Some(&new_cwd) != last_shell_cwd.as_ref() {
+                                if Some(&new_cwd) != last_shell_cwd.as_ref() {
                                     last_shell_cwd = Some(new_cwd.clone());
                                     on_meta(PtyMeta {
                                         session_id: session_id.clone(),
@@ -934,13 +968,13 @@ fn cached_nt_query() -> Option<NtQueryFn> {
         // ntdll.dll is always loaded in every Windows process — use
         // GetModuleHandleA (no refcount bump) instead of LoadLibraryA.
         let ntdll = windows::Win32::System::LibraryLoader::GetModuleHandleA(
-            windows::core::PCSTR(b"ntdll.dll\0".as_ptr()),
+            windows::core::PCSTR(c"ntdll.dll".as_ptr() as _),
         ).ok()?;
         let func = windows::Win32::System::LibraryLoader::GetProcAddress(
             ntdll,
-            windows::core::PCSTR(b"NtQueryInformationProcess\0".as_ptr()),
+            windows::core::PCSTR(c"NtQueryInformationProcess".as_ptr() as _),
         )?;
-        Some(std::mem::transmute(func))
+        Some(std::mem::transmute::<unsafe extern "system" fn() -> isize, NtQueryFn>(func))
     })
 }
 
@@ -1041,6 +1075,9 @@ unsafe fn read_mem<T: Copy>(
         Some(&mut read),
     )
     .ok()?;
+    if read != std::mem::size_of::<T>() {
+        return None;
+    }
     Some(())
 }
 
@@ -1066,6 +1103,44 @@ fn extract_osc_title(data: &str) -> Option<String> {
             }
         }
         i += 1;
+    }
+    None
+}
+
+/// Extract a Windows directory path from a terminal title string.
+///
+/// PowerShell sets the title to the CWD but does NOT call SetCurrentDirectory,
+/// so process_cwd() returns a stale path. Common title formats:
+///   "C:\Users\foo"
+///   "PS C:\Users\foo>"
+///   "Administrator: C:\Windows\System32"
+///   "Windows PowerShell"  (no path — skip)
+fn extract_windows_path_from_title(title: &str) -> Option<String> {
+    // Match a drive-letter path (X:\...) that appears at the start of the
+    // title or after a known prefix ("PS ", "Administrator: "). This avoids
+    // false-matching titles like "vim C:\temp\file.txt".
+    // UNC paths (\\server\share) are not handled — worth a follow-up.
+    let t = title.trim();
+    // Strip known prefixes to find the path at the "start"
+    let stripped = t
+        .strip_prefix("Administrator: ")
+        .or_else(|| t.strip_prefix("PS "))
+        .unwrap_or(t);
+    let bytes = stripped.as_bytes();
+    if bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && bytes[2] == b'\\'
+    {
+        // Extract to end of path (stop at '>' or end of string)
+        let path_end = bytes
+            .iter()
+            .position(|&c| c == b'>')
+            .unwrap_or(bytes.len());
+        let path = stripped[..path_end].trim().trim_end_matches('\\');
+        if !path.is_empty() {
+            return Some(path.to_string());
+        }
     }
     None
 }
@@ -1139,7 +1214,7 @@ fn is_local_hostname(host: &str) -> bool {
         }
         String::new()
     });
-    !local.is_empty() && host == local.as_str()
+    !local.is_empty() && host.eq_ignore_ascii_case(local.as_str())
 }
 
 fn whoami() -> String {
@@ -1208,3 +1283,170 @@ fn expand_path(_home: &str, path: &str) -> String {
 
 // Wrapper to implement portable_pty::Child for std::process::Child
 // end of module
+
+#[cfg(test)]
+mod pty_tests {
+    use super::*;
+
+    // --- extract_osc7 ---
+
+    #[test]
+    fn osc7_basic_remote() {
+        let data = "\x1b]7;file://ubuntu22/home/user\x07";
+        let (host, path) = extract_osc7(data).unwrap();
+        assert_eq!(host, "ubuntu22");
+        assert_eq!(path, "/home/user");
+    }
+
+    #[test]
+    fn osc7_localhost() {
+        let data = "\x1b]7;file://localhost/tmp\x07";
+        let (host, path) = extract_osc7(data).unwrap();
+        assert_eq!(host, "localhost");
+        assert_eq!(path, "/tmp");
+    }
+
+    #[test]
+    fn osc7_empty_host() {
+        let data = "\x1b]7;file:///home/user\x07";
+        let (host, path) = extract_osc7(data).unwrap();
+        assert_eq!(host, "");
+        assert_eq!(path, "/home/user");
+    }
+
+    #[test]
+    fn osc7_percent_encoded_path() {
+        let data = "\x1b]7;file://host/home/my%20dir\x07";
+        let (_, path) = extract_osc7(data).unwrap();
+        assert_eq!(path, "/home/my dir");
+    }
+
+    #[test]
+    fn osc7_windows_forward_slash() {
+        // PowerShell OSC 7 injection sends forward slashes
+        let data = "\x1b]7;file://DESKTOP-ABC/C:/Users/foo\x07";
+        let (host, path) = extract_osc7(data).unwrap();
+        assert_eq!(host, "DESKTOP-ABC");
+        assert_eq!(path, "/C:/Users/foo");
+    }
+
+    #[test]
+    fn osc7_rejects_traversal() {
+        let data = "\x1b]7;file://host/home/../../etc/passwd\x07";
+        assert!(extract_osc7(data).is_none());
+    }
+
+    #[test]
+    fn osc7_st_terminator() {
+        // ESC \ (ST) instead of BEL
+        let data = "\x1b]7;file://host/path\x1b\\";
+        let (host, path) = extract_osc7(data).unwrap();
+        assert_eq!(host, "host");
+        assert_eq!(path, "/path");
+    }
+
+    #[test]
+    fn osc7_picks_last_in_burst() {
+        let data = "\x1b]7;file://h/old\x07some output\x1b]7;file://h/new\x07";
+        let (_, path) = extract_osc7(data).unwrap();
+        assert_eq!(path, "/new");
+    }
+
+    // --- extract_osc_title ---
+
+    #[test]
+    fn osc_title_basic() {
+        let data = "\x1b]0;My Title\x07";
+        assert_eq!(extract_osc_title(data).unwrap(), "My Title");
+    }
+
+    #[test]
+    fn osc_title_type2() {
+        let data = "\x1b]2;Window Title\x07";
+        assert_eq!(extract_osc_title(data).unwrap(), "Window Title");
+    }
+
+    #[test]
+    fn osc_title_no_match() {
+        assert!(extract_osc_title("plain text").is_none());
+    }
+
+    #[test]
+    fn osc_title_powershell_path() {
+        let data = "\x1b]0;C:\\Users\\foo\x07";
+        assert_eq!(extract_osc_title(data).unwrap(), "C:\\Users\\foo");
+    }
+
+    // --- extract_windows_path_from_title ---
+
+    #[test]
+    fn win_title_bare_path() {
+        assert_eq!(
+            extract_windows_path_from_title("C:\\Users\\foo"),
+            Some("C:\\Users\\foo".into())
+        );
+    }
+
+    #[test]
+    fn win_title_ps_prefix() {
+        assert_eq!(
+            extract_windows_path_from_title("PS C:\\Users\\foo>"),
+            Some("C:\\Users\\foo".into())
+        );
+    }
+
+    #[test]
+    fn win_title_admin_prefix() {
+        assert_eq!(
+            extract_windows_path_from_title("Administrator: C:\\Windows\\System32"),
+            Some("C:\\Windows\\System32".into())
+        );
+    }
+
+    #[test]
+    fn win_title_trailing_backslash() {
+        assert_eq!(
+            extract_windows_path_from_title("C:\\"),
+            Some("C:".into())
+        );
+    }
+
+    #[test]
+    fn win_title_no_path() {
+        assert!(extract_windows_path_from_title("Windows PowerShell").is_none());
+    }
+
+    #[test]
+    fn win_title_embedded_path_rejected() {
+        // "vim C:\temp\file" should NOT match — path not at start
+        assert!(extract_windows_path_from_title("vim C:\\temp\\file").is_none());
+    }
+
+    // --- percent_decode ---
+
+    #[test]
+    fn percent_decode_space() {
+        assert_eq!(percent_decode("/my%20dir"), "/my dir");
+    }
+
+    #[test]
+    fn percent_decode_utf8() {
+        // 你 = E4 BD A0
+        assert_eq!(percent_decode("/%E4%BD%A0"), "/你");
+    }
+
+    #[test]
+    fn percent_decode_passthrough() {
+        assert_eq!(percent_decode("/plain/path"), "/plain/path");
+    }
+
+    // --- SSH regex (frontend equivalent) ---
+
+    #[test]
+    fn ssh_regex_rejects_drive_letter() {
+        let re = regex::Regex::new(r"^(\[[^\]]+\]|[^/:]{2,}):(/.*$)").unwrap();
+        assert!(!re.is_match("C:/Users/foo"), "single-letter host should not match");
+        assert!(re.is_match("ubuntu22:/home/user"));
+        assert!(re.is_match("[::1]:/tmp"));
+    }
+}

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -5,10 +5,14 @@ use std::path::PathBuf;
 pub struct SessionMeta {
     pub id: String,
     pub name: String,
-    pub kind: String,            // "shell" | "agent"
+    pub kind: String,            // "shell" | "agent" | "ssh"
     pub agent: Option<String>,   // "claude" | "kiro" | "codex" | etc
     pub command: Option<String>, // original launch command
     pub cwd: Option<String>,
+    #[serde(default)]
+    pub host: Option<String>,    // remote hostname (SSH sessions)
+    #[serde(default)]
+    pub pre_ssh_name: Option<String>, // original session name before SSH switch
     pub pinned: bool,
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ const AGENT_INFO: Record<string, { mono: string; color: string; name: string }> 
 
 let sessionCounter = 0;
 
-interface SessionMeta { id: string; name: string; kind: string; agent: string | null; command: string | null; cwd: string | null; pinned: boolean; }
+interface SessionMeta { id: string; name: string; kind: string; agent: string | null; command: string | null; cwd: string | null; host: string | null; pre_ssh_name: string | null; pinned: boolean; }
 
 function makeSession(name: string): Session {
   const idx = sessionCounter++;
@@ -56,7 +56,9 @@ export default function App() {
   const persistSessions = useCallback((ss: Session[]) => {
     const metas: SessionMeta[] = ss.map(s => ({
       id: s.id, name: s.name, kind: s.kind, agent: (s as any)._agent || null,
-      command: (s as any)._command || null, cwd: s.cwd || null, pinned: s.pinned,
+      command: (s as any)._command || null, cwd: s.cwd || null,
+      host: s.host || null, pre_ssh_name: (s as any)._preSSH?.name || null,
+      pinned: s.pinned,
     }));
     invoke("save_sessions", { sessions: metas }).catch(() => {});
   }, []);
@@ -74,16 +76,29 @@ export default function App() {
             const idx = parseInt(m.id.replace("s", "")) || i;
             if (idx >= maxIdx) maxIdx = idx + 1;
             const agentInfo = m.agent ? AGENT_INFO[m.agent] : null;
-            return {
-              id: m.id, name: m.name, short: m.name, kind: m.kind as any,
+            // SSH sessions are restored as shell — we don't auto-reconnect.
+            // The _preSSH snapshot is reconstructed from persisted pre_ssh_name
+            // so that if the user SSHs again and exits, the original name restores.
+            const wasSsh = m.kind === "ssh" && m.host;
+            const shellColor = AVATAR_COLORS[i % AVATAR_COLORS.length];
+            const sess: any = {
+              id: m.id,
+              name: wasSsh ? (m.pre_ssh_name || m.name) : m.name,
+              short: wasSsh ? (m.pre_ssh_name || m.name) : m.name,
+              kind: agentInfo ? m.kind : "shell",
               avatar: agentInfo
                 ? { mono: agentInfo.mono, color: agentInfo.color }
-                : { mono: "SH", color: AVATAR_COLORS[i % AVATAR_COLORS.length] },
+                : { mono: "SH", color: shellColor },
               status: "idle" as const, unread: 0, pinned: m.pinned, muted: false,
               lastActive: Date.now(), lastPreview: "", lines: [],
-              cwd: m.cwd || "~",
+              cwd: wasSsh ? "~" : (m.cwd || "~"),
               _agent: m.agent, _command: m.command,
-            } as Session & { _agent?: string; _command?: string };
+            };
+            // Preserve pre-SSH snapshot so future SSH→exit cycles restore correctly
+            if (m.pre_ssh_name) {
+              sess._preSSH = { name: m.pre_ssh_name, short: m.pre_ssh_name, avatarMono: "SH", avatarColor: shellColor };
+            }
+            return sess as Session & { _agent?: string; _command?: string };
           });
           sessionCounter = maxIdx;
           setSessions(restored);
@@ -95,7 +110,8 @@ export default function App() {
           // `session_cwd` — the pty-meta listener may not be registered in time
           // for the backend's opportunistic initial emit.
           for (const m of saved) {
-            const spawnCwd = m.cwd && m.cwd !== "~" ? m.cwd : null;
+            // SSH sessions store remote paths — don't use them as local PTY cwd
+            const spawnCwd = m.cwd && m.cwd !== "~" && !m.host ? m.cwd : null;
             invoke("create_session", { id: m.id, cols: 120, rows: 40, command: null, cwd: spawnCwd })
               .then(() => invoke<string | null>("session_cwd", { id: m.id }))
               .then(cwd => {
@@ -164,9 +180,41 @@ export default function App() {
           }
         }
 
-        // Update cwd from hook
+        // Update cwd — detect SSH sessions from "host:/path" format.
+        // The regex requires path to start with / so Windows paths like
+        // "C:\foo" (no leading /) are never mismatched as SSH.
         if (metaCwd) {
-          updates.cwd = metaCwd;
+          const m = metaCwd.match(/^(\[[^\]]+\]|[^/:]+):(\/.*)$/);
+          const isRemote = m && m[1] !== "localhost" && s.kind !== "agent";
+          if (isRemote) {
+            updates.host = m![1];
+            updates.cwd = m![2];
+            if (s.kind !== "ssh") {
+              // Save pre-SSH snapshot so we can restore on exit
+              (updates as any)._preSSH = {
+                name: s.name, short: s.short,
+                avatarColor: s.avatar.color, avatarMono: s.avatar.mono,
+              };
+              updates.kind = "ssh";
+              updates.name = m![1];
+              updates.short = m![1];
+              updates.avatar = { mono: "SS", color: "var(--av-5)" };
+            }
+          } else {
+            updates.cwd = metaCwd;
+            // Revert to shell if was SSH but now local
+            if (s.kind === "ssh") {
+              const snap = (s as any)._preSSH;
+              updates.kind = "shell";
+              updates.host = null as any; // clear host (spread will set it)
+              updates.name = snap?.name || s.name;
+              updates.short = snap?.short || s.short;
+              updates.avatar = {
+                mono: snap?.avatarMono || "SH",
+                color: snap?.avatarColor || AVATAR_COLORS[0],
+              };
+            }
+          }
         }
 
         // Backend state (vscreen regex / hook) drives the semantic flags;
@@ -348,8 +396,8 @@ export default function App() {
                 fontSize: 11, color: "var(--text-dim)",
                 overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
                 maxWidth: 400,
-              }} title={active.cwd}>
-                {active.cwd}
+              }} title={active.host ? `${active.host}:${active.cwd}` : active.cwd}>
+                {active.host ? `${active.host}:${active.cwd}` : active.cwd}
               </span>
             )}
             <div style={{ flex: 1 }} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import Sidebar from "./Sidebar";
 import XtermPane from "./XtermPane";
 import CmdK from "./CmdK";
 import { Ic } from "./Icons";
-import { Session, PtyOutput, AVATAR_COLORS, isMenuMod } from "./types";
+import { Session, SessionKind, PtyOutput, AVATAR_COLORS, isMenuMod } from "./types";
 import { loadSavedTheme, applyTheme, getAllThemes, getCurrentTheme, setCurrentTheme, addImportedTheme, TerminalTheme } from "./themes";
 import "./App.css";
 
@@ -55,9 +55,9 @@ export default function App() {
   // Persist session metadata whenever sessions change
   const persistSessions = useCallback((ss: Session[]) => {
     const metas: SessionMeta[] = ss.map(s => ({
-      id: s.id, name: s.name, kind: s.kind, agent: (s as any)._agent || null,
-      command: (s as any)._command || null, cwd: s.cwd || null,
-      host: s.host || null, pre_ssh_name: (s as any)._preSSH?.name || null,
+      id: s.id, name: s.name, kind: s.kind, agent: s._agent || null,
+      command: s._command || null, cwd: s.cwd || null,
+      host: s.host || null, pre_ssh_name: s._preSSH?.name || null,
       pinned: s.pinned,
     }));
     invoke("save_sessions", { sessions: metas }).catch(() => {});
@@ -81,11 +81,11 @@ export default function App() {
             // so that if the user SSHs again and exits, the original name restores.
             const wasSsh = m.kind === "ssh" && m.host;
             const shellColor = AVATAR_COLORS[i % AVATAR_COLORS.length];
-            const sess: any = {
+            const sess: Session = {
               id: m.id,
               name: wasSsh ? (m.pre_ssh_name || m.name) : m.name,
               short: wasSsh ? (m.pre_ssh_name || m.name) : m.name,
-              kind: agentInfo ? m.kind : "shell",
+              kind: (agentInfo ? m.kind : "shell") as SessionKind,
               avatar: agentInfo
                 ? { mono: agentInfo.mono, color: agentInfo.color }
                 : { mono: "SH", color: shellColor },
@@ -93,12 +93,11 @@ export default function App() {
               lastActive: Date.now(), lastPreview: "", lines: [],
               cwd: wasSsh ? "~" : (m.cwd || "~"),
               _agent: m.agent, _command: m.command,
+              _preSSH: m.pre_ssh_name
+                ? { name: m.pre_ssh_name, short: m.pre_ssh_name, avatarMono: "SH", avatarColor: shellColor }
+                : null,
             };
-            // Preserve pre-SSH snapshot so future SSH→exit cycles restore correctly
-            if (m.pre_ssh_name) {
-              sess._preSSH = { name: m.pre_ssh_name, short: m.pre_ssh_name, avatarMono: "SH", avatarColor: shellColor };
-            }
-            return sess as Session & { _agent?: string; _command?: string };
+            return sess;
           });
           sessionCounter = maxIdx;
           setSessions(restored);
@@ -165,7 +164,7 @@ export default function App() {
             updates.name = info.name;
             updates.short = info.name;
             updates.avatar = { mono: info.mono, color: info.color };
-            (updates as any)._agent = agent;
+            updates._agent = agent;
           }
         }
 
@@ -174,24 +173,26 @@ export default function App() {
         // backend (e.g. detecting codex while session is still labelled kiro)
         // could silently overwrite command with an unrelated process's args.
         if (command) {
-          const currentAgent = (s as any)._agent;
+          const currentAgent = s._agent;
           if (!currentAgent || !agent || agent === currentAgent) {
-            (updates as any)._command = command;
+            updates._command = command;
           }
         }
 
         // Update cwd — detect SSH sessions from "host:/path" format.
         // The regex requires path to start with / so Windows paths like
-        // "C:\foo" (no leading /) are never mismatched as SSH.
+        // "C:\foo" (no leading /) are never mismatched as SSH. The bare-host
+        // branch requires 2+ chars so "C:/Users/foo" (Git Bash) can't match
+        // with host="C".
         if (metaCwd) {
-          const m = metaCwd.match(/^(\[[^\]]+\]|[^/:]+):(\/.*)$/);
+          const m = metaCwd.match(/^(\[[^\]]+\]|[^/:]{2,}):(\/.*)$/);
           const isRemote = m && m[1] !== "localhost" && s.kind !== "agent";
           if (isRemote) {
             updates.host = m![1];
             updates.cwd = m![2];
             if (s.kind !== "ssh") {
               // Save pre-SSH snapshot so we can restore on exit
-              (updates as any)._preSSH = {
+              updates._preSSH = {
                 name: s.name, short: s.short,
                 avatarColor: s.avatar.color, avatarMono: s.avatar.mono,
               };
@@ -204,9 +205,9 @@ export default function App() {
             updates.cwd = metaCwd;
             // Revert to shell if was SSH but now local
             if (s.kind === "ssh") {
-              const snap = (s as any)._preSSH;
+              const snap = s._preSSH;
               updates.kind = "shell";
-              updates.host = null as any; // clear host (spread will set it)
+              updates.host = undefined;
               updates.name = snap?.name || s.name;
               updates.short = snap?.short || s.short;
               updates.avatar = {
@@ -271,7 +272,7 @@ export default function App() {
 
   const createSession = useCallback(async (name: string, command?: string) => {
     const session = makeSession(name);
-    (session as any)._command = command || null;
+    session._command = command || null;
     setSessions(prev => { const next = [...prev, session]; persistSessions(next); return next; });
     setActiveId(session.id);
     try {
@@ -294,8 +295,8 @@ export default function App() {
   const resumeSession = useCallback(async (id: string) => {
     const s = sessionsRef.current.find(x => x.id === id);
     if (!s) return;
-    const agent = (s as any)._agent;
-    const cmd = (s as any)._command;
+    const agent = s._agent;
+    const cmd = s._command;
     const AGENT_RESUME: Record<string, string> = {
       claude: "claude --resume", kiro: "kiro-cli chat --resume", codex: "codex resume --last",
     };

--- a/src/XtermPane.tsx
+++ b/src/XtermPane.tsx
@@ -41,6 +41,15 @@ function getOrCreate(sessionId: string): { term: Terminal; fit: FitAddon } {
       if (k === "k" || k === "n") return false;
     }
     if (document.querySelector(".cmdk-backdrop")) return false;
+    // Windows IME fix: when an IME composition is active, block modifier
+    // keys so the browser's default IME handling commits text correctly.
+    // Note: Ctrl keydown sets e.ctrlKey=true in Chromium, so it's already
+    // excluded by the outer guard — no need to check keyCode 17 here.
+    if (e.isComposing && !e.ctrlKey && !e.metaKey) {
+      const k = e.keyCode;
+      // 16=Shift, 18=Alt, 20=CapsLock
+      if (k === 16 || k === 18 || k === 20) return false;
+    }
     return true;
   });
 
@@ -89,6 +98,49 @@ export default function XtermPane({ sessionId }: Props) {
     // Mount: attach to DOM
     if (!term.element) {
       term.open(container);
+      // Windows IME fix for Sogou and other third-party IMEs.
+      //
+      // Sogou has TWO different behaviors that both lose text:
+      //
+      // 1. Sogou Chinese mode → type English → Shift to commit:
+      //    Sogou bypasses composition entirely. No compositionstart/end.
+      //    It inserts text via a bare "input" event (inputType=insertText,
+      //    isComposing=false). xterm.js may or may not handle this depending
+      //    on internal state (_keyDownSeen). Sogou intercepts keydown events
+      //    so xterm.js's _keyDownSeen is false → text lost.
+      //
+      // 2. Standard composition → compositionend with empty textarea:
+      //    Some IMEs clear textarea.value before compositionend fires.
+      //    xterm.js reads empty string via setTimeout(0) → text lost.
+      //
+      // Fix: listen for both patterns. Use defaultPrevented to detect if
+      // xterm.js already handled the event (avoids double-send).
+      const ta = term.textarea;
+      if (ta && !(ta as any).__imePatched) {
+        // Pattern 1: Sogou non-composition insertText
+        ta.addEventListener("input", ((e: InputEvent) => {
+          if (e.defaultPrevented) return;
+          if (e.inputType !== "insertText" || e.isComposing || !e.data) return;
+          // Sogou inserts multiple characters at once (e.g. "hello") via a
+          // single input event. Normal keystrokes produce single-char input
+          // events that xterm.js already handles via keydown. Only intercept
+          // multi-char inserts to avoid double-sending normal typing.
+          if (e.data.length <= 1) return;
+          invoke("write_session", { id: sessionId, data: e.data });
+          ta.value = "";
+        }) as EventListener, true);
+
+        // Pattern 2: compositionend with empty textarea
+        ta.addEventListener("compositionend", (e: CompositionEvent) => {
+          const text = e.data;
+          if (!text) return;
+          if (!ta.value || ta.value.trim() === "") {
+            invoke("write_session", { id: sessionId, data: text });
+          }
+        }, true);
+
+        (ta as any).__imePatched = true;
+      }
     } else {
       // Re-attach existing element
       while (container.firstChild) container.removeChild(container.firstChild);

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,10 @@ export interface Session {
   user?: string;
   port?: number;
   pid?: number;
+  // Internal fields — not persisted directly, but used at runtime
+  _agent?: string | null;
+  _command?: string | null;
+  _preSSH?: { name: string; short: string; avatarMono: string; avatarColor: string } | null;
 }
 
 export interface PtyOutput { session_id: string; data: string; }


### PR DESCRIPTION
- Parse OSC 7 (file://hostname/path) from PTY output to track remote shell CWD across SSH sessions
- Implement Windows process_cwd via NtQueryInformationProcess + PEB
- Auto-detect SSH sessions in frontend, switch avatar/name/kind
- Persist SSH host and pre-SSH session name for correct restore
- Add percent-decode for URI paths (CJK, spaces)
- Add IPv6 hostname support ([::1] bracket wrapping)
- Add local hostname detection to avoid false SSH identification
- Add path traversal validation (reject .. components)
- Add cwd_via_remote_osc7 flag with proper reset on SSH exit
- Add PBI struct size static assertion for x64 safety