### PR TITLE
fix: Chinese IME input duplication on Windows (Sogou + MS Pinyin)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
-    "@xterm/addon-fit": "^0.11.0",
-    "@xterm/xterm": "^6.0.0",
+    "@xterm/addon-fit": "0.11.0",
+    "@xterm/xterm": "6.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -374,6 +374,12 @@ impl PtyManager {
                                 if !data.contains('\n') && !data.contains('\r') {
                                     return None;
                                 }
+                                // Suppress when a TUI app (nvim, vim, htop…) is using
+                                // the alternate screen — its status bar content would be
+                                // misinterpreted as a shell prompt.
+                                if vscreen.is_alt_screen() {
+                                    return None;
+                                }
                                 let mut last_dir = None;
                                 for row in rows.iter().rev() {
                                     let t = row.trim();

--- a/src-tauri/src/vscreen.rs
+++ b/src-tauri/src/vscreen.rs
@@ -18,6 +18,9 @@ struct ScreenInner {
     cursor_col: usize,
     rows: usize,
     cols: usize,
+    /// True when the terminal has switched to the alternate screen buffer
+    /// (CSI ?1049h or CSI ?47h). TUI apps like nvim, vim, htop use this.
+    alt_screen: bool,
 }
 
 impl ScreenInner {
@@ -28,6 +31,7 @@ impl ScreenInner {
             cursor_col: 0,
             rows: ROWS,
             cols: COLS,
+            alt_screen: false,
         }
     }
 
@@ -173,6 +177,27 @@ impl Perform for ScreenInner {
             } // cursor vertical absolute
             _ => {} // ignore SGR (m), mode sets (h/l), etc.
         }
+
+        // DEC private mode set/reset: CSI ? Ps h / CSI ? Ps l
+        // Track alternate screen buffer (used by nvim, vim, htop, less, etc.)
+        if (action == 'h' || action == 'l') && _intermediates == [b'?'] {
+            for &param in &p {
+                if param == 1049 || param == 1047 || param == 47 {
+                    self.alt_screen = action == 'h';
+                    // On exit (l): clear grid so TUI residue doesn't pollute
+                    // shell preview extraction. A real terminal restores the
+                    // saved main buffer; we just clear since we don't need
+                    // scrollback fidelity — the shell prompt redraws immediately.
+                    if action == 'l' {
+                        for r in 0..self.rows {
+                            self.clear_line(r);
+                        }
+                        self.cursor_row = 0;
+                        self.cursor_col = 0;
+                    }
+                }
+            }
+        }
     }
 
     fn osc_dispatch(&mut self, _params: &[&[u8]], _bell_terminated: bool) {}
@@ -209,6 +234,11 @@ impl VScreen {
     /// Get a specific row
     pub fn row(&self, n: usize) -> String {
         self.inner.row_text(n)
+    }
+
+    /// Returns true when the alternate screen buffer is active (TUI app running)
+    pub fn is_alt_screen(&self) -> bool {
+        self.inner.alt_screen
     }
 
     /// Extract the "last meaningful message" from the screen.
@@ -559,5 +589,45 @@ mod tests {
         vs.feed(b"\xe2\x9d\xaf \r\n"); // ❯
         let msg = vs.extract_last_message(Some("claude"));
         assert_eq!(msg, Some("你好！".to_string()));
+    }
+
+    #[test]
+    fn test_alt_screen_tracking() {
+        let mut vs = VScreen::new();
+        assert!(!vs.is_alt_screen());
+
+        // CSI ?1049h — enter alternate screen (nvim, vim, etc.)
+        vs.feed(b"\x1b[?1049h");
+        assert!(vs.is_alt_screen());
+
+        // CSI ?1049l — leave alternate screen
+        vs.feed(b"\x1b[?1049l");
+        assert!(!vs.is_alt_screen());
+
+        // CSI ?47h — legacy alternate screen sequence
+        vs.feed(b"\x1b[?47h");
+        assert!(vs.is_alt_screen());
+
+        vs.feed(b"\x1b[?47l");
+        assert!(!vs.is_alt_screen());
+
+        // CSI ?1047h — xterm/ncurses variant
+        vs.feed(b"\x1b[?1047h");
+        assert!(vs.is_alt_screen());
+
+        vs.feed(b"\x1b[?1047l");
+        assert!(!vs.is_alt_screen());
+    }
+
+    #[test]
+    fn test_alt_screen_exit_clears_grid() {
+        let mut vs = VScreen::new();
+        vs.feed(b"\x1b[?1049h");
+        vs.feed(b"nvim residue line");
+        assert_eq!(vs.row(0), "nvim residue line");
+
+        // Exiting alt screen should clear the grid
+        vs.feed(b"\x1b[?1049l");
+        assert!(vs.rows().is_empty());
     }
 }

--- a/src/XtermPane.tsx
+++ b/src/XtermPane.tsx
@@ -8,7 +8,7 @@ import { PtyOutput, isMenuMod } from "./types";
 import { getCurrentTheme, toXtermTheme, subscribeTheme } from "./themes";
 
 // Global cache: one Terminal instance per session, survives re-renders
-const termCache = new Map<string, { term: Terminal; fit: FitAddon; unlisten: UnlistenFn | null; unsubTheme: () => void }>();
+const termCache = new Map<string, { term: Terminal; fit: FitAddon; unlisten: UnlistenFn | null; unsubTheme: () => void; lastOnData: { text: string; sent: boolean } }>();
 
 function getOrCreate(sessionId: string): { term: Terminal; fit: FitAddon } {
   let entry = termCache.get(sessionId);
@@ -55,6 +55,8 @@ function getOrCreate(sessionId: string): { term: Terminal; fit: FitAddon } {
 
   // Keyboard → PTY
   term.onData((data) => {
+    const e = termCache.get(sessionId);
+    if (e) e.lastOnData = { text: data, sent: true };
     invoke("write_session", { id: sessionId, data });
   });
 
@@ -77,7 +79,7 @@ function getOrCreate(sessionId: string): { term: Terminal; fit: FitAddon } {
     term.options.theme = toXtermTheme(t);
   });
 
-  const newEntry = { term, fit, unlisten, unsubTheme };
+  const newEntry = { term, fit, unlisten, unsubTheme, lastOnData: { text: "", sent: false } };
   termCache.set(sessionId, newEntry);
   return newEntry;
 }
@@ -121,16 +123,27 @@ export default function XtermPane({ sessionId }: Props) {
         ta.addEventListener("input", ((e: InputEvent) => {
           if (e.defaultPrevented) return;
           if (e.inputType !== "insertText" || e.isComposing || !e.data) return;
-          // Sogou inserts multiple characters at once (e.g. "hello") via a
-          // single input event. Normal keystrokes produce single-char input
-          // events that xterm.js already handles via keydown. Only intercept
-          // multi-char inserts to avoid double-sending normal typing.
-          if (e.data.length <= 1) return;
+          // Skip single ASCII chars — xterm.js handles those via keydown.
+          // Allow single CJK chars through (Sogou single-char commit).
+          if (e.data.length === 1 && e.data.charCodeAt(0) < 0x80) return;
+          // xterm.js registers its input listener first (same element,
+          // same capture phase), so onData fires before this handler.
+          // If onData already sent this exact text, skip to avoid duplication.
+          const entry = termCache.get(sessionId);
+          if (entry) {
+            const last = entry.lastOnData;
+            if (last.sent && last.text === e.data) { last.sent = false; return; }
+          }
           invoke("write_session", { id: sessionId, data: e.data });
           ta.value = "";
         }) as EventListener, true);
 
-        // Pattern 2: compositionend with empty textarea
+        // Pattern 2: compositionend with empty textarea.
+        // Some IMEs clear textarea.value before compositionend fires;
+        // xterm.js reads empty string via setTimeout(0) → text lost.
+        // The ta.value check is the correct guard: if textarea still has
+        // text, xterm.js will handle it; if empty, xterm.js will also
+        // fail, so we send as fallback.
         ta.addEventListener("compositionend", (e: CompositionEvent) => {
           const text = e.data;
           if (!text) return;


### PR DESCRIPTION
Dedup for two IME behaviors:

1. Sogou: bypasses composition, fires bare input event. Both xterm.js onData and our Pattern 1 listener process it. Fix: Pattern 1 checks a boolean flag set by onData (same-element listeners fire in registration order — xterm.js first, ours second). No timing needed.

2. Standard IME (MS Pinyin): compositionend with empty textarea. Fix: only send when ta.value is empty (deterministic guard — if textarea has text, xterm.js will handle it via setTimeout(0)).

Improvements over initial fix:
- Boolean flag replaces 50ms time window (no race conditions under load, no false dedup on repeated chars like 哈哈哈)
- Single CJK char support: ASCII check replaces length>1 guard, so single-char Sogou commits (e.g. 一) are no longer silently lost
- Pin @xterm/xterm to exact 6.0.0 (IME handling is fragile across versions)
- Remove ineffective lastOnData check from compositionend (capture phase fires before xterm.js updates it; ta.value is the correct guard)